### PR TITLE
Connect ViewModel to Activity and fixed errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+
+    // add below plugin
+    id 'kotlin-kapt'
 }
 
 android {
@@ -18,6 +21,14 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        // Fix warning for exporting schema, this will write out the schema to a
+        // schemas subfolder of your project folder
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas")
+            }
+        }
     }
 
     buildTypes {
@@ -27,11 +38,13 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        // Fix build error after adding kotlin-kapt
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        // Fix build error after adding kotlin-kapt
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
@@ -54,8 +67,9 @@ dependencies {
     annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.6.1'
 
     // Room
-    implementation "androidx.room:room-runtime:$room_version"
-    annotationProcessor "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    androidTestImplementation "androidx.room:room-testing$room_version"
 
     // Floating action button && Card view
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/src/main/java/com/example/architectureexample/MainActivity.kt
+++ b/app/src/main/java/com/example/architectureexample/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.architectureexample
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,11 +11,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.example.architectureexample.ui.theme.ArchitectureExampleTheme
 
 class MainActivity : ComponentActivity() {
+    private lateinit var noteViewModel: NoteViewModel
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         setContent {
             ArchitectureExampleTheme {
                 // A surface container using the 'background' color from the theme
@@ -26,6 +31,20 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+        noteViewModel = ViewModelProvider(
+            this,
+            ViewModelProvider.AndroidViewModelFactory.getInstance(application)
+        )[NoteViewModel::class.java]
+
+        noteViewModel.getAllNotes().observe(
+            this,
+            Observer { list ->
+                list?.let {
+                    // Update RecyclerView
+                    Toast.makeText(applicationContext, "Yeet", Toast.LENGTH_SHORT).show()
+                }
+            })
     }
 }
 

--- a/app/src/main/java/com/example/architectureexample/NoteViewModel.kt
+++ b/app/src/main/java/com/example/architectureexample/NoteViewModel.kt
@@ -2,7 +2,9 @@ package com.example.architectureexample
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class NoteViewModel(application: Application) :
@@ -10,15 +12,15 @@ class NoteViewModel(application: Application) :
 
     private val repository: NoteRepository = NoteRepository(application, viewModelScope)
 
-    fun insert(note: Note) = viewModelScope.launch {
+    fun insert(note: Note) = viewModelScope.launch(Dispatchers.IO) {
         repository.insert(note)
     }
 
-    fun update(note: Note) = viewModelScope.launch {
+    fun update(note: Note) = viewModelScope.launch(Dispatchers.IO) {
         repository.update(note)
     }
 
-    fun delete(note: Note) = viewModelScope.launch {
+    fun delete(note: Note) = viewModelScope.launch(Dispatchers.IO) {
         repository.delete(note)
     }
 
@@ -26,7 +28,7 @@ class NoteViewModel(application: Application) :
         repository.deleteAllNotes()
     }
 
-    fun getAllNotes() {
-        repository.getAllNotes()
+    fun getAllNotes(): LiveData<List<Note>> {
+        return repository.getAllNotes()
     }
 }


### PR DESCRIPTION
Connected our view model to our main activity. Added a temporary toast to show we're referencing it's logic. 

I ran into an app crash after connection our view model to our main activity. The error was fixed through these two question/answers (https://stackoverflow.com/questions/69079963/how-to-set-compilejava-task-11-and-compilekotlin-task-1-8-jvm-target-com) && this is the error I was seeing (https://stackoverflow.com/questions/75480173/android-studio-build-error-compiledebugjavawithjavac-task-current-target-it-1)

After fixing the app crash I got a warning for not providing if we're exporting our schema in our NoteDatabase class. I was able to fix that with this (https://stackoverflow.com/questions/44322178/room-schema-export-directory-is-not-provided-to-the-annotation-processor-so-we)