### PR TITLE
Added the AddNoteButton and AddNoteActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,8 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     def room_version = '2.5.1'
 
     // Lifecycle
@@ -69,7 +71,7 @@ dependencies {
     // Room
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-    androidTestImplementation "androidx.room:room-testing$room_version"
+    androidTestImplementation "androidx.room:room-testing:$room_version"
 
     // Floating action button && Card view
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,11 +12,23 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.ArchitectureExample"
         tools:targetApi="31">
+<!--    The parent activity lets the system know what to go back to when we
+        close the AddNoteActivity-->
+<!--    Change the theme for both Activities because of crashing app, since we're
+        extending the ActionBarActivity we need to have a theme with an ActionBar-->
+        <activity
+            android:name=".AddNoteActivity"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/AppTheme"
+            android:exported="false" />
+<!--    The singleTop launchMode lets us go back to the MainActivity without
+        going back into the onCreate method, since we just want to go back-->
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTop"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.ArchitectureExample">
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/architectureexample/AddNoteActivity.kt
+++ b/app/src/main/java/com/example/architectureexample/AddNoteActivity.kt
@@ -1,0 +1,120 @@
+package com.example.architectureexample
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.widget.EditText
+import android.widget.NumberPicker
+import android.widget.Toast
+
+/*
+This Activity is supposed to hold the UI that displays
+EditText: The title you want for this Note
+EditText: The description you want for this Note
+NumberPicker: The priority level for this Note
+
+NOTE: It would be best practice to create another ViewModel to send our
+data to the database. We wouldn't want to reuse the NoteViewModel we already
+have since this Activity only inserts, it doesn't do any of the other operations.
+
+Instead we're going to send the data from this Activity to the MainActivity and
+let it handle it with NoteViewModel which has the insert operation.
+
+This add note activity is acting as an input form and doesn't communication with
+any other layers. To do this we will use the start activity for result method.
+Allows us to start the activity from our main activity then do our logic and send
+data back to our main activity when this one is closed.
+We do this over intent extras, for intent extras we need a key and for
+best practice we use constants string that uses the package name.
+ */
+class AddNoteActivity : AppCompatActivity() {
+    companion object {
+        // Key for sending our title, description and priority over Intents
+        const val EXTRA_TITLE: String = "com.example.architectureexample.EXTRA_TITLE"
+        const val EXTRA_DESCRIPTION: String = "com.example.architectureexample.EXTRA_DESCRIPTION"
+        const val EXTRA_PRIORITY: String = "com.example.architectureexample.EXTRA_PRIORITY"
+    }
+
+    lateinit var editTextTitle: EditText
+    lateinit var editTextDescription: EditText
+    lateinit var numberPickerPriority: NumberPicker
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_note)
+
+        editTextTitle = findViewById(R.id.edit_text_title)
+        editTextDescription = findViewById(R.id.edit_text_description)
+        numberPickerPriority = findViewById(R.id.number_picker_priority)
+
+        numberPickerPriority.minValue = 1
+        numberPickerPriority.maxValue = 666
+
+        // In order to get the X in to top left corner
+        supportActionBar?.setHomeAsUpIndicator(R.drawable.baseline_close)
+
+        // This is the title for the ActionBar
+        title = "Add Note"
+    }
+
+    /*
+    We want to confirm the input, when we click the save menu icon in the action bar.
+    We get the icon there by override and adding our own menu
+     */
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        super.onCreateOptionsMenu(menu)
+        val menuInflater: MenuInflater = menuInflater
+        // This tells the system to use our add note menu, as the menu of this activity
+        menuInflater.inflate(R.menu.add_note_menu, menu)
+
+        return true
+    }
+
+    /*
+    To handle click on our items we have to override this method.
+    The **item** is the menu item that's clicked
+    When our save button is clicked we want to save the note
+     */
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        super.onOptionsItemSelected(item)
+        return when (item.itemId) {
+            R.id.save_note -> {
+                saveNote()
+                return true
+            }
+
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+
+    private fun saveNote() {
+        val title: String = editTextTitle.text.toString()
+        val description = editTextDescription.text.toString()
+        val priority: Int = numberPickerPriority.value
+
+        // Invalid state, don't save the Note and show a toast
+        if (title.trim().isEmpty() || description.trim().isEmpty()) {
+            Toast.makeText(this, "Please insert a title and description", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // We want to send our information back to the MainActivity so it can
+        // insert this Note into the database
+        // We use an Intent to send data back to the Activity that started this one
+        val data: Intent = Intent()
+        data.putExtra(EXTRA_TITLE, title)
+        data.putExtra(EXTRA_DESCRIPTION, description)
+        data.putExtra(EXTRA_PRIORITY, priority)
+
+        // We indicate if the input was successful or not. If user hits back button
+        // it wasn't successful but if user hits save button and everything is fine
+        // than set result as ok, and pass our data intent. finish() closes activity
+        // Use these two values in the MainActivity to see if everything worked
+        setResult(RESULT_OK, data)
+        finish()
+    }
+}

--- a/app/src/main/java/com/example/architectureexample/MainActivity.kt
+++ b/app/src/main/java/com/example/architectureexample/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.example.architectureexample
 
+import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,12 +15,30 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.architectureexample.ui.theme.ArchitectureExampleTheme
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 class MainActivity : ComponentActivity() {
+
+    companion object {
+        const val ADD_NOTE_REQUEST: Int = 1
+    }
+
     private lateinit var noteViewModel: NoteViewModel
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
+
+        // Add the Add Note Button
+        val buttonAddNote: FloatingActionButton = findViewById(R.id.button_add_note)
+        buttonAddNote.setOnClickListener {
+            // Intent is a Java class so we do it this way instead AddNoteActivity.class
+            val intent: Intent = Intent(this, AddNoteActivity::class.java)
+
+            // Typical way of calling an intent is doing startActivity(intent) but we
+            // are expecting some data back so we do
+            // Request code is used to distinguish between request
+            startActivityForResult(intent, ADD_NOTE_REQUEST)
+        }
 
         // To use a recycler view you must provide an adapter and a layout manager
         // RecyclerView is our main_activity.xml
@@ -45,6 +66,29 @@ class MainActivity : ComponentActivity() {
                     adapter.notes = list
                 }
             })
+    }
+
+    // This is where we get the result back when the Activity we called with an intent
+    // is closed.
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        // TODO: Update this deprecated override
+        super.onActivityResult(requestCode, resultCode, data)
+
+        // This handles what request we're dealing with
+        // Check if we're dealing with this Activities request and if result is ok
+        if (requestCode == ADD_NOTE_REQUEST && resultCode == RESULT_OK) {
+            val title: String = data?.getStringExtra(AddNoteActivity.EXTRA_TITLE)!!
+            val description: String = data?.getStringExtra(AddNoteActivity.EXTRA_DESCRIPTION)!!
+            val priority: Int = data?.getIntExtra(AddNoteActivity.EXTRA_PRIORITY, 1)!!
+
+            val note: Note = Note(title, description, priority)
+            noteViewModel.insert(note)
+
+            Toast.makeText(this, "Note saved", Toast.LENGTH_SHORT).show()
+        } else {
+            // This is for when the cancel button is pressed instead
+            Toast.makeText(this, "Note not saved", Toast.LENGTH_SHORT).show()
+        }
     }
 }
 

--- a/app/src/main/res/drawable/baseline_add.xml
+++ b/app/src/main/res/drawable/baseline_add.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_close.xml
+++ b/app/src/main/res/drawable/baseline_close.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_save.xml
+++ b/app/src/main/res/drawable/baseline_save.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_add_note.xml
+++ b/app/src/main/res/layout/activity_add_note.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--In order to display our EditText below each other use -->
+<!--LinearLayout over ConstraintLayout-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:context=".AddNoteActivity">
+
+<!--    We want to add two edit text and a # picker here. The save button-->
+<!--    will be a menu option, which we add over the activity-->
+
+    <EditText
+        android:id="@+id/edit_text_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Title"
+        android:inputType="text"/>
+
+
+    <EditText
+        android:id="@+id/edit_text_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Description"
+        android:inputType="textMultiLine"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Priority:"
+        android:layout_marginTop="8dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
+
+    <NumberPicker
+        android:id="@+id/number_picker_priority"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -13,4 +13,13 @@
         android:layout_height="match_parent"
         tools:listitem="@layout/note_item"/>
 
+<!--    This is adding a add button to the bottom right corner of the MainActivity-->
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/button_add_note"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="32dp"
+        android:src="@drawable/baseline_add" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/add_note_menu.xml
+++ b/app/src/main/res/menu/add_note_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+<!--    This item is being used to show the save buttom.-->
+<!--    showAsAction set to ifRoom so it's dispalyed if there's room-->
+    <item
+        android:id="@+id/save_note"
+        android:icon="@drawable/baseline_save"
+        android:title="Save"
+        app:showAsAction="ifRoom"/>
+</menu>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,4 +2,5 @@
 <resources>
 
     <style name="Theme.ArchitectureExample" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar" />
 </resources>


### PR DESCRIPTION
This pull request handles a quite a bit of things, I'm going to try and list all of them.

1) builde.gradle we just added dependencies of ActionBar(appcompat) and fixed a bug with missing ":" before a version number

2) AndroidManifest we added the MainActivity as a parent of AddNoteActivity so when we hit close or back button it'll take us back to Main. Also had an app crash because of us extending AppCompatActivity on AddNoteActivity, this requires us to use a theme that has an ActionBar, this helped solve the app crash (https://stackoverflow.com/questions/21814825/you-need-to-use-a-theme-appcompat-theme-or-descendant-with-this-activity)

3) AddNoteActivity we added this Activity as an input form, it'll send data back to MainActivity so we don't have to create another ViewModel for it. That's handled through intent and start activity for result method.
This class has two EditText for title and description of a note, and a NumberPicker for the priority of the Note.  We also added a save button to the ActionBar. Then we just capture the data, and send it back to Main after Save button is clicked.

4) MainActivity we added our button to add a note at the bottom right, and when it gets clicked we launch a our AddNoteActivity through an intent, but our intent is launched through a startActivityForResult which expects a return when that activity is closed. It's handled in the override method onActivityResult where we reference our ViewModel and insert our new Note, so we can put it in the database. We also display some toast to the user.

5) We added three vector assets to our red/drawable dir: add (+), close (x) and save 

6) activity_add_note.xml we added this layout for our AddNoteActivity which just holds two EditText and a NumberPicker

7) main_activity.xml added floating action button

8) Added menu res dir and added the add_note_menu.xml to add our save button

9) Updated themes to use an ActionBar to fix crash mentioned in "2)"