### PR TITLE
Add ability to update nodes by clicking them

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 <!--    Change the theme for both Activities because of crashing app, since we're
         extending the ActionBarActivity we need to have a theme with an ActionBar-->
         <activity
-            android:name=".AddNoteActivity"
+            android:name=".AddEditNoteActivity"
             android:parentActivityName=".MainActivity"
             android:exported="false" />
 <!--    The singleTop launchMode lets us go back to the MainActivity without

--- a/app/src/main/java/com/example/architectureexample/AddEditNoteActivity.kt
+++ b/app/src/main/java/com/example/architectureexample/AddEditNoteActivity.kt
@@ -30,9 +30,10 @@ data back to our main activity when this one is closed.
 We do this over intent extras, for intent extras we need a key and for
 best practice we use constants string that uses the package name.
  */
-class AddNoteActivity : AppCompatActivity() {
+class AddEditNoteActivity : AppCompatActivity() {
     companion object {
         // Key for sending our title, description and priority over Intents
+        const val EXTRA_ID: String = "com.exmaple.architectureexample.EXTRA_ID"
         const val EXTRA_TITLE: String = "com.example.architectureexample.EXTRA_TITLE"
         const val EXTRA_DESCRIPTION: String = "com.example.architectureexample.EXTRA_DESCRIPTION"
         const val EXTRA_PRIORITY: String = "com.example.architectureexample.EXTRA_PRIORITY"
@@ -56,8 +57,19 @@ class AddNoteActivity : AppCompatActivity() {
         // In order to get the X in to top left corner
         supportActionBar?.setHomeAsUpIndicator(R.drawable.baseline_close)
 
-        // This is the title for the ActionBar
-        title = "Add Note"
+        // Our title now changes based on how we got to this Activity
+        // The intent will only have an ID when we update
+        val intent: Intent = intent
+        if (intent.hasExtra(EXTRA_ID)) {
+            title = "Edit Note"
+            editTextTitle.setText(intent.getStringExtra(EXTRA_TITLE))
+            editTextDescription.setText(intent.getStringExtra(EXTRA_DESCRIPTION))
+            numberPickerPriority.value = intent.getStringExtra(EXTRA_PRIORITY)?.toInt() ?: 1
+            numberPickerPriority.value = intent.getIntExtra(EXTRA_PRIORITY, -1)
+        } else {
+            // This is the title for the ActionBar
+            title = "Add Note"
+        }
     }
 
     /*
@@ -110,6 +122,12 @@ class AddNoteActivity : AppCompatActivity() {
         data.putExtra(EXTRA_TITLE, title)
         data.putExtra(EXTRA_DESCRIPTION, description)
         data.putExtra(EXTRA_PRIORITY, priority)
+
+        // TODO: I need to figure out how to get ID so I can send it back to MainActivity
+        val id: Int = intent.getIntExtra(EXTRA_ID, -1)
+        if (id != -1) {
+            data.putExtra(EXTRA_ID, id)
+        }
 
         // We indicate if the input was successful or not. If user hits back button
         // it wasn't successful but if user hits save button and everything is fine

--- a/app/src/main/java/com/example/architectureexample/Note.kt
+++ b/app/src/main/java/com/example/architectureexample/Note.kt
@@ -18,5 +18,5 @@ class Note(
     val title: String,
     val description: String,
     val priority: Int,
-    @PrimaryKey(autoGenerate = false) val id: Int? = null
+    @PrimaryKey(autoGenerate = false) var id: Int? = null
 )

--- a/app/src/main/java/com/example/architectureexample/NoteAdapter.kt
+++ b/app/src/main/java/com/example/architectureexample/NoteAdapter.kt
@@ -19,6 +19,9 @@ the RecyclerView. It determines how to items are arranged, such as in a linear
 vertical list or a grid.
  */
 class NoteAdapter : RecyclerView.Adapter<NoteAdapter.NoteHolder>() {
+
+    private lateinit var listener: OnItemClickListener
+
     // Our list of Notes is initialize to avoid null pointers
     var notes: List<Note> = arrayListOf()
         set(value) {
@@ -39,15 +42,16 @@ class NoteAdapter : RecyclerView.Adapter<NoteAdapter.NoteHolder>() {
     recycles teh existing views.
     The ViewHolder acts as a container for views in a RecyclerView
      */
-    class NoteHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val textViewTitle: TextView
-        val textViewDescription: TextView
-        val textViewPriority: TextView
+    inner class NoteHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val textViewTitle: TextView = itemView.findViewById(R.id.text_view_title)
+        val textViewDescription: TextView = itemView.findViewById(R.id.text_view_description)
+        val textViewPriority: TextView = itemView.findViewById(R.id.text_view_priority)
 
         init {
-            textViewTitle = itemView.findViewById(R.id.text_view_title)
-            textViewDescription = itemView.findViewById(R.id.text_view_description)
-            textViewPriority = itemView.findViewById(R.id.text_view_priority)
+            itemView.setOnClickListener {
+                val position: Int = adapterPosition
+                listener.onItemClick(notes[position])
+            }
         }
     }
 
@@ -73,5 +77,13 @@ class NoteAdapter : RecyclerView.Adapter<NoteAdapter.NoteHolder>() {
         holder.textViewTitle.text = currentNote.title
         holder.textViewDescription.text = currentNote.description
         holder.textViewPriority.text = currentNote.priority.toString()
+    }
+
+    interface OnItemClickListener {
+        fun onItemClick(note : Note);
+    }
+
+    fun setOnItemClickListener(listener: OnItemClickListener) {
+        this.listener = listener
     }
 }

--- a/app/src/main/res/layout/activity_add_note.xml
+++ b/app/src/main/res/layout/activity_add_note.xml
@@ -8,7 +8,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp"
-    tools:context=".AddNoteActivity">
+    tools:context=".AddEditNoteActivity">
 
 <!--    We want to add two edit text and a # picker here. The save button-->
 <!--    will be a menu option, which we add over the activity-->


### PR DESCRIPTION
Here we implemented the broadcaster and observer methodology with our click listeners and registers. 
I made the notes on the MainActivity clickable by adding an interface to our Adapter and a setter for that interface (listener). 
We had to add a click listener to our NoteHolder class, that'll call our interface method onItemClick(). 
Then on MainActivity we call our setOnItemClickListener for our adapter and pass in an anonymous inner class that'll override our one method onItemClick and here we create our Intent with all our text that'll pass to our AddEditNoteActivity. 
The one extra thing we did here was pass in note.id so when we go to update our room it'll know where id (primary key). 
We also added another ID when we startActivity, so our AddEditNoteActivity knows if it's Edit or Add. 
Then that activity handles what title to show and if it'll have prefilled info or not. The rest is essentially the same