### PR TITLE
Adding animations and extend ListAdapter

### DIFF
--- a/app/src/main/java/com/example/architectureexample/MainActivity.kt
+++ b/app/src/main/java/com/example/architectureexample/MainActivity.kt
@@ -79,10 +79,10 @@ class MainActivity : AppCompatActivity() {
         // it's statues
         noteViewModel.getAllNotes().observe(
             this,
-            Observer { list ->
-                list?.let {
-                    // Update RecyclerView
-                    adapter.notes = list
+            Observer { notes ->
+                notes?.let {
+                    // Update RecyclerView, updated with ListAdapter method
+                    adapter.submitList(notes)
                 }
             })
 


### PR DESCRIPTION
Updated the extended class for our Adapter from RecyclerView.Adapter<NoteAdapter.NoteHolder>() to ListAdapter<Note, NoteAdapter.NoteViewHolder>(NoteDiffUtil()), then updated the override methods for NoteDiffUtil class which tells us if a Note is the same in terms of primary key, and if the contents is different for when updated. 
Then we just updated some of our logic to use the ListAdapters methods.

The ListAdapter handles animations by getting the exact view that's updating or changing instead of making the LayoutManger draw out the whole RecyclerView again. 